### PR TITLE
Formatting/wording changes. Add 'don't obstruct' to active participat…

### DIFF
--- a/COC.md
+++ b/COC.md
@@ -4,86 +4,87 @@ Copyright &copy; 2016 Fantasyland Institute of Learning. All Rights Reserved.
 
 ## Statement of Purpose
 
-The Fantasyland Institute of Learning Code of Professionalism (FCOP) dictates the terms and conditions under which we allow you to participate in the Community.
+The Fantasyland Institute of Learning Code of Professionalism (FCOP) dictates the terms and conditions under which we allow you to participate in the _community_.
 
-The purpose of FCOP is to ensure inclusiveness and productivity in a pluralistic society. To accomplish this goal, we restrict the Community to peaceful people, and protect such people from Discrimination, Stereotyping, Harassment, Judgmental Communication, and violations of privacy. 
+The purpose of FCOP is to ensure inclusiveness and productivity in a pluralistic society. To accomplish this goal, we restrict the _community_ to peaceful people, and protect such people from _discrimination_, _stereotyping_, _harassment_, _judgmental communication_, and violations of privacy.
 
-FCOP is explicitly not intended to impose any system of politics, morals, or values onto Members.
+FCOP is explicitly not intended to impose any system of politics, morals, or values onto _members_.
 
 ## Short-Form
 
-We welcome all peaceful people to participate in the Community. We do not allow Discrimination, Harassment, Judgmental Communication, or violations of privacy. We do not exclude any peaceful people from our Community unless they have demonstrated an inability to follow our terms and conditions.
+We welcome all peaceful people to participate in the _community_. We do not allow _discrimination_, _harassment_, _judgmental communication_, or violations of privacy. We do not exclude any peaceful people from our _community_ unless they have demonstrated an inability to follow our terms and conditions.
 
 ## Welcome Statement
 
 We welcome peaceful people of all genders, gender-expressions, sexual-orientations, gender-orientations, races, ethnic origins, skin colors, physical handicaps, mental handicaps, ages, sizes, political views, religious views, philosophies, beliefs, and attitudes.
 
-We pledge that we will not tolerate Discrimination, Harassment, Judgmental Communication, or violations of privacy. We pledge to hold ourselves to these same standards, and in so doing set a positive example for others to follow.
+We pledge that we will not tolerate _discrimination_, _harassment_, _judgmental communication_, or violations of privacy. We pledge to hold ourselves to these same standards and, in so doing, set a positive example for others to follow.
 
-We greatly value integrity and pledge to establish the highest levels of trust in Members.
+We greatly value integrity and pledge to establish the highest levels of trust in _members_.
 
 ## Behavior
 
-### Active Participation 
+### Active Participation
 
-During Active Participation, you must behave as described in this section.
+During _active participation_, you must behave as described in this section.
 
-* **Assume the Best**. You must assume the best intention when others communicate with you. If you don’t understand what someone meant, or have questions about it, you must ask them directly rather than speculating or spreading rumors.
-* **Don't Stereotype**. You must treat everyone as unique, and may not assume anything about one characteristic of a person based on other characteristics.
+* **Assume the Best**. Assume the best intention when others communicate with you. If you don’t understand what someone meant, or have questions about it, ask them directly rather than speculating or spreading rumors.
+* **Don't Stereotype**. Treat everyone as unique. Do not infer characteristics of a person based on their [perceived] membership in some group or category.
 * **Don't Communicate Judgmentally**. You must not communicate the idea that any person, place, thing, idea, or action is superior or inferior to any other. Instead, talk about observations, models, analyses, and your own personal preferences.
-* **Don't Harass**. You must not interact with anyone who does not consent. For verbal and written interaction, you may assume consent for the first interaction, until the recipient communicates otherwise. For physical interaction, close physical proximity, and persistent gaze, you must assume non-consent, until the person clearly and unambiguously communicates otherwise.
-* **Don't Pry**. You must not read, watch, or listen to the private communications of other members (including trying to read their screens or listening to their private conversations).
+* **Don't Harass**. Do not interact with anyone who does not consent. For verbal and written interaction you may assume consent for the first interaction, until the recipient communicates otherwise. For physical interaction, close physical proximity, and persistent gaze, you must assume non-consent until the person clearly and unambiguously communicates otherwise.
+* **Don't Pry**. Do not go out of your way to read, watch, or listen to the private communications of other members (including trying to read their screens or listening to their private conversations). If you do overhear a private conversation do not share it on social media.
+* **Don't Obstruct**. Attempts to disrupt speakers or prevent members from physically entering public spaces will not be tolerated.
 
 ### Inactive Participation
 
-During Inactive Participation, you must behave as described in this section.
+During _inactive participation_, you must behave as described in this section.
 
-* **Be Peaceful**. You must not engage in criminal activity.
-* **Don't Dox**. We do not allow members to disseminate any details about others learned within the Community without express permission, including but not limited to real name, address, phone number, or photo identity.
-* **Don't Shame**. You must not discuss a member's behavior in the Community outside the Community, without express permission.
+* **Be Peaceful**. Do not engage in criminal activity.
+* **Don't Dox**. Do not disseminate any details about others learned within the _community_ without express permission, including but not limited to real name, address, phone number, or photo identity.
+* **Don't Shame**. You must not discuss a member's behavior inside the _community_ outside of the _community_ without express permission.
 
 ## Privacy
 
-**Private Communication**. During Active Participation, you may take phone calls, direct messages, emails, and other semi-private forms of communication. Although private communication is not bound by FCOP, we expect all communication that can be seen or overheard by other members will uphold FCOP.
- 
-**Private Consumption**. During Active Participation, you may consume material on your own personal devices and from your own channels of communication, and this material does not have to conform to FCOP, assuming the material is not easily discernible to others.
+**Private Communication**. During _active participation_, you may take phone calls, direct messages, emails, and other semi-private forms of communication. Although private communication is not bound by FCOP, we expect all communication that can be seen or overheard by other members will uphold FCOP.
+
+**Private Consumption**. During _active participation_, you may consume material on your own personal devices and from your own channels of communication, and this material does not have to conform to FCOP, assuming the material is not easily discernible to others.
 
 ## Violations
 
-**No Victimless Crime**. If you are a Victim but you do not feel victimized, you may choose to not report the violation.
+**No Victimless Crime**. If you are a _victim_ but you do not feel victimized, you may choose to not report the _violation_.
 
-**Reporting Process**. Active Participation violations must be reported to us within 15 days by Victims. Inactive Participation violations may be reported at any time, and by anyone, even non-Members.
+**Reporting Process**. _Active participation_ violations must be reported to us within 15 days by Victims. Inactive Participation violations may be reported at any time, and by anyone, even non-_members_.
 
-**Unofficial Resolution**. For minor offenses and in cases where they prefer doing so, we encourage Victims to speak to Violators, using the language of non-violent communication (NVC). If you would like to do this with the help of an independent mediator, contact us and we will arrange for one.
+**Unofficial Resolution**. For minor offenses and in cases where they prefer doing so, we encourage _victims_ to speak to _violators_, using the language of non-violent communication (NVC). If you would like to do this with the help of an independent mediator, contact us and we will arrange for one.
 
-**Official Resolution**. If you want an official intervention, we will appoint a judge. The judge will speak individually to all parties, including witnesses, before deciding on a course of action, which will involve rejecting the reported violation, or accepting it and imposing a penalty on the Violator.
+**Official Resolution**. If you want an official intervention, we will appoint a judge. The judge will speak individually to all parties, including witnesses, before deciding on a course of action, which will involve rejecting the reported violation, or accepting it and imposing a penalty on the _violator_.
 
-**Penalties**. Violators may be warned, forced into training, counseling or mediation, or ejected and banned from the Community, at the sole discretion of the judge.
+**Penalties**. _violators_ may be warned, forced into training, counseling or mediation, or ejected and banned from the _community_, at the sole discretion of the judge.
 
-**Social Rehabilitation**. No one can be banished for life, only for a determined number of years, not to exceed 5 years. Formerly banned parties can be reintegrated into the Community through a rehabilitation process determined by us.
+**Social Rehabilitation**. No one can be banished for life, only for a determined number of years, not to exceed 5 years. Formerly banned parties can be reintegrated into the _community_ through a rehabilitation process determined by us.
 
 **Confidentiality**. Reporting a violation is a confidential process. We will not publish information on any reported incident or the parties involved in the incident. Note that criminal behavior of any kind will not be kept confidential.
 
 ## Terms
 
- * **Active Participation**. We define Active Participation to include the behavior of members while they are in the boundaries of the Community.
+ * **Active Participation**. We define Active Participation to include the behavior of members while they are in the boundaries of the _community_.
  * **Behavior**. We define behavior to include all and only observable actions of people, and to explicitly exclude any private thoughts, beliefs, attitudes, and emotions.
  * **Communication**. We define communication as any transmission of information between people, including but not limited to verbal, written, electronic, pictorial, gestural, and tactile.
- * **Community**. We define our Community as a group of people with a shared professional interest that exists at some location (online or geographical) and within some span of time. The boundaries of the community are dictated by us, but cannot extend in space or time to any place where we do not have the actual or legal ability to impose FCOP-prescribed penalties on Violators.
- * **Discrimination**. We define Discrimination as any favoritism shown or withheld to someone either on the basis of a stereotype or a non-relevant characteristic.
- * **Harassment**. We define Harassment as an attempt to interact with someone who does not consent to the interaction.
- * **Inactive Participation**. We define Inactive Participation to include the behavior of members at all times and under all circumstances.
+ * **Community**. We define our _community_ as a group of people with a shared professional interest that exists at some location (online or geographical) and within some span of time. The boundaries of the community are dictated by us, but cannot extend in space or time to any place where we do not have the actual or legal ability to impose FCOP-prescribed penalties on _violators_.
+ * **Discrimination**. We define _discrimination_ as any favoritism shown or withheld to someone either on the basis of a stereotype or a non-community related group membership.
+ * **Harassment**. We define _harassment_ as an attempt to interact with someone who does not consent to the interaction.
+ * **Inactive Participation**. We define _inactive participation_ to include the behavior of members at all times and under all circumstances.
  * **Interaction**. We define interaction as any one-on-one communication, physical contact, close proximity, or persistent gaze. Interaction explicitly does not include opt-in, broadcast-based communication within the Community.
- * **Judgmental Communication**. We define Judgmental Communication as any communication which asserts or implies that something has intrinsic superiority or inferiority. This includes all forms of name-calling, but explicitly excludes any language that qualifies as non-violent communication (NVC).
- * **Members**. We define a member of the Community as a peaceful individual who we allow to actively participate in the Community.
- * **Peaceful**. We define peaceful individuals as individuals who, in our sole estimation, will not initiate any kind of criminal behavior against others if allowed to participate in the Community.
- * **Stereotyping**. We define stereotyping as behavior that infers or implies one characteristic of an individual based on a different characteristic.
- * **Victim**. We define Victims as people for whom one or more of the following holds:
+ * **Judgmental Communication**. We define _judgmental communication_ as any communication which asserts or implies that something has intrinsic superiority or inferiority. This includes all forms of name-calling, but explicitly excludes any language that qualifies as non-violent communication (NVC).
+ * **Members**. We define a member of the _community_ as a peaceful individual who we allow to actively participate in the _community_.
+ * **Peaceful**. We define peaceful individuals as individuals who, in our sole estimation, will not initiate any kind of criminal behavior against others if allowed to participate in the _community_.
+ * **Stereotyping**. We define stereotyping as behavior that infers or implies one characteristic of an individual based on their [perceived] membership ins some group or category.
+ * **Victim**. We define _victims_ as people for whom one or more of the following holds:
 
-    * **Harassment**. Someone has Harassed them.
-    * **Discrimination**. Someone has Discriminated against them.
+    * **Harassment**. Someone has _harassed_ them.
+    * **Discrimination**. Someone has _discriminated_ against them.
     * **Stereotyping**. Someone has stereotyped them or a group they belong to.
     * **Judgmental Communication**. Someone has communicated judgmentally about them, their beliefs, or their values; or someone has communicated judgmentally about a group they belong to.
     * **Privacy Violation**. Someone has violated their privacy.
- * **Violator**. We define Violator as someone who has broken the terms and conditions of FCOP.
- * **We**. We define "we" to be those who have the actual or legal ability to impose FCOP-prescribed penalties on Violators within the physical or virtual boundaries of the Community.
+ * **Violator**. We define _violator_ as someone who has broken the terms and conditions of FCOP.
+ * **We**. We define "we" to be those who have the actual or legal ability to impose FCOP-prescribed penalties on _violators_ within the physical or virtual boundaries of the _community_.


### PR DESCRIPTION
I re-added the part about non-judgemental communication. I need to learn more about NVC to understand what it implies.

I added a "don't obstruct" guideline which would preclude attempts at "no platforming."

I also left in the redundant: "If you do overhear a private conversation do not share it on social media." under - Don't Pry - to doubly emphasize the point (which is already implied by "Don't Shame").

I also changed "Don't Shame" back to its original intent: "You must not discuss a member's behavior inside the _community_ outside of the _community_ without express permission."