### PR TITLE
Prepare for 1.0 release

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,123 +1,119 @@
 # Fantasyland Institute of Learning - Code Of Professionalism (FCOP)
+## Version 1.0
 
-Copyright &copy; 2016 - 2017 Fantasyland Institute of Learning. All Rights Reserved.
+Copyright &copy; 2016 - 2018 Fantasyland Institute of Learning. All Rights Reserved.
 
-## Statement of Purpose
+## Introduction
 
 The Fantasyland Institute of Learning Code of Professionalism (FCOP) dictates the terms and conditions under which we allow you to participate in the _community_.
 
 The purpose of FCOP is to facilitate an inclusive and diverse _community_ of professionals who productively work toward shared professional goals.
 
-In service of this purpose, we open the _community_ to all _civil_ individuals and we require that all _members_ refrain from _unprofessional behavior_. We do not impose any ideology onto _members_, nor do we restrict participation based on people's _personal attributes_ or their _behavior_ in other communities.
+In service of this purpose, we open the _community_ to all _qualified individuals_ and we require that all _members_ refrain from _unprofessional conduct_. Except as otherwise noted, we do not impose any ideology onto _members_, nor do we restrict participation based on people's _personal attributes_ or their _conduct_ in other communities.
 
-## Welcome Statement
+## Community Conduct
 
-We welcome all _civil_ individuals regardless of any _personal attributes_ they have that are orthogonal to the professional goals of the _community_.
+We strongly encourage _members_ to assume the best in every _interaction_; to be open, honest, and empathic in all _communication_; and to demonstrate politeness and professional courtesy in every situation.
 
-We pledge that we will enforce the terms and conditions set forth in FCOP, and that we will hold ourselves to these same standards, thereby setting a positive example for others to follow.
+We welcome any closed group of _members_ to engage in any _conduct_ for which there is explicit and unanimous mutual consent. In the absence of such consent, we impose the following restrictions on _conduct_, which are further clarified by the **Glossary**.
 
-## Expected Behavior
-
-We permit only _civil_ individuals to participate in the _community_. We further require that _members_ refrain from _unprofessional behavior_.
-
-### Active Participation
-
-We encourage _members_ to assume the best in every _interaction_; to be open, honest, and empathic in all _communication_; and to demonstrate politeness and professional courtesy in every situation.
-
-We welcome any closed group of _members_ to engage in any _behavior_ for which there is explicit and unanimous mutual consent. In the absence of such consent, we impose the following restrictions during _active participation_, which are further clarified by the **Glossary**.
-
-* **Don't Discriminate**. Do not show or withhold favoritism on the basis of a _stereotype_.
-* **Don't Harass**. Only _interact_ with people who wish you to _interact_ with them.
+* **Don't Harass**. Only _interact_ with people who consent to the _interaction_.
 * **Don't Pry**. Do not attempt to infer the private content or _communication_ of others.
 * **Don't Insult**. Do not _insult_ others or aspects of who they are.
 
-These requirements on _behavior_ apply to _members_ only while they are actively participating in the _community_. The standing of _members_ is unaffected by _behavior_ that does not comply with these requirements if this _behavior_ occurs in other communities.
+These requirements on _conduct_ apply to _members_ only while they are _actively participating_ in the _community_. Except as otherwise noted, the standing of _members_ is unaffected by _conduct_ that does not comply with these requirements if this _conduct_ occurs in other communities.
 
-### Inactive Participation
+## External Conduct
 
 During _inactive participation_, we impose the following restrictions, which are further clarified by the **Glossary**.
 
 * **Don't Dox**. Do not publish details of _members_ that you learn about during _active participation_.
 * **Don't Retaliate**. Do not _retaliate_ against _members_ for the resolution or reporting of an _incident_.
 
-These requirements on _behavior_ apply to _members_ at all times, even when they are not actively participating in the _community_.
+These requirements on _conduct_ apply to _members_ at all times, even when they are not actively participating in the _community_.
 
 ## Reporting
 
-**Reporting Requirements**. _Active participation incidents_ must be reported to us within 15 days by _aggrieved members_. We will investigate third-party reports at our sole discretion. _Inactive participation incidents_ must be reported to us within 5 years of their occurrence, by _members_ or _non-members_. Information that any _member_ or _non-member_ believes may affect our view of the _civility_ of individuals may be reported at any time.
+**Unofficial Resolution**. For unofficial resolution, we encourage _aggrieved members_ to speak to _accused members_ directly, using the language of non-violent communication (NVC). At the request of an _aggrieved member_, we will appoint a mediator who can facilitate an unofficial resolution and serve as a witness for subsequent reporting.
 
-**Unofficial Resolution**. For unofficial resolution, we encourage _aggrieved members_ to speak to _accused members_ directly, using the language of non-violent communication (NVC). At the request of an _aggrieved member_, we will appoint a mediator who can facilitate an unofficial resolution and serve as a witness.
-
-**Official Resolution**. For official resolution, _aggrieved members_ must contact us, and we will appoint an _arbiter_. The _arbiter_ will speak individually to all parties, including witnesses, before deciding on a course of action, which will involve rejecting the _incident_, or accepting it as a _violation_ and imposing a consequence on the _violator_.
+**Official Resolution**. For official resolution, _aggrieved members_ must report the _incident_ to us and request an official resolution. We will appoint an _arbiter_, who will speak individually to all parties, including witnesses, before deciding on a course of action. The course of action will involve rejecting the _incident_, or accepting it as a _violation_ and imposing a consequence on the _violator_.
 
 **Consequences**. _Violators_ may be asked to apologize or to undergo training, counseling, or mediation as a condition of continued participation. They may also be banned from the _community_, at the sole discretion of the _arbiter_. In no case will the consequence exceed banishment, unless the violation is also governed by separate contractual agreements or local laws. We reserve the right to re-evaluate a previously imposed _consequence_.
 
-**Social Rehabilitation**. We will only banish individuals for a determined number of years, not to exceed 5 years. Formerly banned parties may be reintegrated into the _community_ through a rehabilitation process determined by us.
+**Social Rehabilitation**. We will only banish individuals for a pre-determined time, not to exceed 5 years. We reserve the right to reintegrate banned individuals into the _community_ through our own rehabilitation process.
 
-**Confidentiality**. We may publicly share information about any _violation_ that results in banishment, including personally identifiable information on the violator, limited to name and online identities. We will keep other _incidents_ and the identities of _aggrieved_ and _accused_ confidential to the extent this confidentiality is fully respected by all parties.
+**Confidentiality**. We reserve the right to publicly share information about any _violation_ that results in banishment, including personally identifiable information on the _violator_, limited to name and online identities. In all other cases, we will keep _incidents_ and the identities of _aggrieved_ and _accused_ confidential to the extent this confidentiality is fully respected by all parties.
 
-## Management
+**Reporting Requirements**. _Active participation incidents_ must be reported to us within 15 days by _aggrieved members_. We will investigate third-party reports at our sole discretion. _Inactive participation incidents_ must be reported to us within 5 years of their occurrence. Information that any individual believes may affect our view of the _qualifications_ of an individual may be reported at any time.
 
-**Contact Information**. We pledge to make reasonable efforts to provide contact information for use in reporting _incidents, including an estimate of how quickly _members_ can expect to receive a response.
+## Our Pledges
 
-**Clear Boundaries**. We pledge to make reasonable efforts to provide information on the boundaries of the _community_, including information on any regions in time or space that are partially or fully exempt from FCOP.
+**Enforcement**. We pledge that we will make reasonable efforts to enforce the terms and conditions set forth in FCOP, and to hold ourselves to these same standards, thereby setting a positive example for others to follow.
 
-**Non-coercion**. We pledge to make reasonable efforts to never coerce _members_ into revealing private information, making statements, or otherwise requiring actions that are unnecessary for the scope of participating in a given _community_ activity.
+**Contact Information**. We pledge to make reasonable efforts to provide contact information for use in reporting _incidents_, including an estimate of how quickly _members_ can expect to receive a response.
 
-**Disclosure**. We pledge to make reasonable efforts to provide a written, anonymized summary to _uncivil_ or banned individuals that discloses the rational and evidence resulting in their status. Such individuals may share this disclosure privately or publicly providing they do so in its entirety.
+**Community Boundaries**. We pledge to make reasonable efforts to provide information on the boundaries of the _community_, including information on any regions in time or space that are partially or fully exempt from FCOP.
 
-**Unbiased Arbitration**. We pledge to make reasonable efforts to appoint balanced or neutral _arbiters_ for every arbitration, ideally without special relationships to _aggrieved_ or _accused_, or vested interest in any specific outcome.
+**Non-Coercion**. We pledge to make reasonable efforts to never coerce _members_ into revealing private information, making statements, or otherwise requiring actions that are unnecessary for the scope of participating in a given _community_ activity.
 
-**Merit Transparency**. We pledge to make reasonable efforts to communicate on whether the status, authority, or responsibility of individual _members_ is awarded or withheld based on _personal attributes_ that are not relevant to their function in the _community_.
+**Disclosure**. We pledge to make reasonable efforts to provide a written, anonymized summary to _unqualified individuals_ that discloses the rational and evidence resulting in their status as _unqualified individuals_. We grant permission for individuals to share this disclosure privately or publicly providing they do so in its entirety.
 
-## Miscellaneous
+**Unbiased Arbitration**. We pledge to make reasonable efforts to appoint balanced or neutral _arbiters_ for every arbitration, without special relationships to _aggrieved_ or _accused_, or vested interest in any specific outcome. In the event that unbiased arbitration is impossible or too onerous, we pledge to disclose all known biases.
 
-**Criminal Behavior**. FCOP is not intended to supplant the laws of governing jurisdictions, but to impose a set of terms and conditions on community membership. _Criminal behavior_ of any kind should be immediately reported to relevant authorities and dealt with as recommended by such authorities. Notwithstanding the foregoing, if _criminal behavior_ also violates FCOP, we reserve the right to deal with such behavior as described herein.
+**Merit Transparency**. We pledge to make reasonable efforts to continuously communicate whether the status, authority, or responsibility of individual _members_ is awarded or withheld based on _personal attributes_ that are not relevant to their function in the _community_.
 
-**Disputes of Interpretation**. In the event there is a dispute about the meaning of any term or clause in FCOP, we alone will clarify the intent, independent of how other FCOP communities have made clarifications. We pledge to be consistent in our interpretation of any ambiguity, rather than utilizing different interpretations in different circumstances.
+**Amendments**. Any part of FCOP, including but not limited to definitions in the glossary, may be unilaterally amended by us. We pledge to clearly specify and distribute such amendments together with FCOP.
 
-**Non-Endorsement**. In recognition of the pluralistic composition of the _community_, the _community_ does not endorse the views, values, religions, politics, beliefs, or attitudes of ourselves or of any _member_ of the _community_. No _member_ ever speaks for or represents the _community_, and neither do we speak for or represent the _community_ unless we are acting in our official capacities (and even then, only for the scope of the task at hand).
+## Disclaimers
 
-**Limitation of Remedy**. In the event we fail to uphold any of our obligations under FCOP, including upholding pledges as made herein, the remedy is limited to a formal public apology and reversal of any negative consequences, unless the breach is governed by separate contractual agreements or local laws.
+**Disputes of Interpretation**. In the event there is a dispute about the meaning of any term or clause in FCOP, we alone will clarify the intent, independent of how other FCOP communities have clarified the meaning. We pledge to be consistent in our interpretation of any ambiguity.
 
-**Amendments**. Any part of FCOP, including but not limited to definitions in the glossary, may be unilaterally amended by us, on condition that we clearly specify and distribute such amendments together with both FCOP, and any statements indicating we have adopted FCOP.
+**Criminal Conduct**. FCOP is not intended to supplant the laws of governing jurisdictions, but to impose a set of terms and conditions on community membership for law-abiding individuals. _Criminal conduct_ of any kind should be immediately reported to relevant authorities and dealt with as recommended by such authorities. Notwithstanding the foregoing, if _criminal conduct_ also violates FCOP, we reserve the right to deal with such conduct as described herein.
+
+**Non-Endorsement**. In recognition of the pluralistic composition of the _community_, the _community_ does not endorse the attitudes, beliefs, moral systems, personality traits, political views, religions, or values of ourselves or of any _member_ of the _community_. No _member_ ever speaks for or represents the _community_, and neither do we speak for or represent the _community_ unless we are acting in our official capacities, and then only for the scope of the task at hand.
+
+**Limitation of Remedy**. FCOP is intended as a legally binding agreement. In the event we fail to uphold any of our pledges as made herein, remedy is limited to a formal public apology and reversal of any consequences (if applicable), unless the breach is governed by separate contractual agreements or local laws.
 
 ## Glossary
 
  * **Accused**. We define _accused_ as a _member_ who has been attributed a _violation_ by an _aggrieved member_.
- * **Active Participation**. We define _active participation_ to include the _behavior_ of _members_ while they are in the boundaries of the _community_.
+ * **Active Participation**. We define _active participation_ to include the _conduct_ of _members_ while they are in the boundaries of the _community_.
  * **Aggrieved**. We define _aggrieved_ as a _member_ who believes that one or more of the following holds:
-    * **Discrimination**. Someone has _discriminated_ against them.
     * **Harassment**. Someone has _harassed_ them.
     * **Prying**. Someone has violated their privacy.
     * **Insulting**. Someone has _insulted_ them or a group they belong to.
  * **Arbiter**. We define _arbiter_ as one or more persons designated by us to resolve an _incident_ report.
- * **Behavior**. We define _behavior_ to include all and only observable actions of people, and to explicitly exclude all _personal attributes_.
- * **Civil**. We define _civil_ individuals as individuals who are not currently _uncivil_.
+ * **Civil**. We define _civil_ individuals as individuals who are not _uncivil_.
  * **Communication**. We define _communication_ as any transmission of information between people, including but not limited to verbal, written, electronic, pictorial, gestural, and tactile.
  * **Community**. We define the _community_ as a group of people with a shared professional interest that exists at some location (online or geographical) and within some span of time. The boundaries of the community are dictated by us, but cannot extend in space or time to any place where we do not have the actual or legal ability to impose FCOP-prescribed consequences on _violators_.
- * **Community Sabotage**. We define _community sabotage_ to be any _behavior_ that does have or is intended to have the effect of harming the professional goals of the _community_, including but not limited to attempting to defund or blackball the _community_, attempting to disrupt or diminish the activities of the _community_, and authoring, spreading, or endorsing libel or slander about the _community_; or encouraging others to do the same. Explicitly excluded from this definition is _communication_ of truthful information regarding the _community_ and truthful criticism on the failure of the _community_ to optimally strive towards its professional goals.
- * **Criminal Behavior**. We define _criminal behavior_ as any behavior that is illegal under the laws of the governing jurisdiction. Explicitly excluded from _criminal behavior_ is any illegal behavior in which those directly and immediately impacted by the behavior are legally adults and do not consider themselves to be victims (including recreational use of drugs, consensual prostitution, failure of adults to wear seat belts, and the like).
- * **Discrimination**. We define _discrimination_ as any favoritism shown or withheld to someone on the basis of a _stereotype_.
+ * **Community Qualification Criteria**. We define _community qualification criteria_ to be published and publicly accessible criteria that are useful and objectively relevant to the professional goals of the _community_. This criteria may include objectively verifiable criteria (such as capability to perform a task), or unverifiable criteria. The satisfaction of all unverifiable criteria, including requirements on the attitudes, beliefs, moral systems, personality traits, political views, religions, and values of an individual, must be determined solely by the individual's own confessions, and may not be determined by third-party statements, except insofar as they are witnesses for the individual's own confessions.
+ * **Community Sabotage**. We define _community sabotage_ to be any _conduct_ that does have or is intended to have the effect of harming the professional goals of the _community_, including but not limited to attempting to defund or blackball the _community_, attempting to disrupt or diminish the activities of the _community_, and authoring, spreading, or endorsing libel or slander about the _community_; or encouraging others to do the same. Explicitly excluded from this definition is _communication_ of truthful information regarding the _community_ and truthful criticism on the failure of the _community_ to optimally strive towards its professional goals.
+* **Conduct**. We define _conduct_ to include all and only observable actions of people, and to explicitly exclude all _personal attributes_.
+ * **Criminal Conduct**. We define _criminal conduct_ as any _conduct_ that is illegal under the laws of the governing jurisdiction. Explicitly excluded from _criminal conduct_ is any illegal _conduct_ in which those directly and immediately impacted by the _conduct_ are legally adults and do not consider themselves to be victims (including recreational use of drugs, consensual prostitution, failure of adults to wear seat belts, and the like).
  * **Doxxing**. We define _doxxing_ to be the unauthorized publication of any _personal attributes_ of identified _members_ learned during _active participation_ and not previously known to the public.
  * **Harassment**. We define _harassment_ as an _interaction_ with someone who does not consent to the _interaction_. For _interactions_ of a professional nature, you may assume consent for the first interaction, until the recipient _communicates_ otherwise (examples include handshakes, looking at someone who is speaking, providing feedback). For all other _interactions_, you must assume non-consent until the person clearly and unambiguously _communicates_ otherwise (examples include persistent gaze at someone who is not speaking, sexual interactions of any kind).
- * **Inactive Participation**. We define _inactive participation_ to include the _behavior_ of _members_ at all times and under all circumstances.
+ * **Inactive Participation**. We define _inactive participation_ to include the _conduct_ of _members_ at all times and under all circumstances.
  * **Incident**. We define _incident_ as a possible infringement of FCOP.
  * **Interaction**. We define _interaction_ as any one-on-one _communication_, physical contact (with person or property), close proximity, or persistent gaze. Explicitly excluded from this definition is opt-in, broadcast-based _communication_ within the _community_.
- * **Members**. We define a _member_ of the _community_ to be any _civil_ individual who we allow to actively participate in the _community_.
+ * **Members**. We define a _member_ of the _community_ to be any _qualified individual_ who participates in the _community_.
  * **Personal Attribute**. We define _personal attribute_ to be an individual as a whole, or the presence or absence of any individual characteristic, including but not limited to age, body mods, ethnic origin, gender, gender-expression, gender-orientation, intellectual disability, physical appearance, physical disability, presented appearance, race, sex, sexual preferences, sexual-orientation, size, skin color, and strength; attitudes, beliefs, moral systems, personality traits, political views, religions, and values; facts, including address, job title, membership in categories or groups, membership in communities, profession, real name, salary, and type and extent of education.
- * **Professional Sabotage**. We define _professional sabotage_ to be any _behavior_ that does have or is intended to have the effect of harming a _member's_ career, including but not limited to attempting to no-platform, blackball, or fire a _member_, or stealing or taking credit for the work of a _member_; or encouraging others to engage in such _behavior_. Explicitly excluded from _professional sabotage_ is all harmful _communication_ that is exclusively motivated by and _communicated_ in terms of the _member_'s failure to fulfill their professional duties.
+ * **Professional Sabotage**. We define _professional sabotage_ to be any _conduct_ that does have or is intended to have the effect of harming a _member's_ career, including but not limited to attempting to no-platform, blackball, or fire a _member_, or stealing or taking credit for the work of a _member_; or encouraging others to engage in such _conduct_. Explicitly excluded from _professional sabotage_ is all harmful _communication_ that is exclusively motivated by and _communicated_ in terms of the _member_'s failure to fulfill their professional duties.
  * **Prying**. We define _prying_ to be any unauthorized attempt (whether legal or illegal) to infer the _communication_ of semi-private forms of communication (including phone calls, direct messages, texts, private conversations), or to infer content on private devices or private channels of communication belonging to other _members_.
+ * **Qualified Individual**. We define _qualified individual_ to refer to any individual for whom the following hold:
+    * We believe the individual is _civil_.
+    * We are not presently banning the individual from the _community_.
+    * The individual further satisfy all _community qualification criteria_.
+ * **Qualifications**. We define the _qualifications_ of an individual to be the minimal set of properties sufficient to determine whether the individual is a _qualified individual_.
  * **Retaliation**. We define _retaliation_ as the imposition of any _negative consequence_ on a _member_ for their unofficial resolution or reporting of an _incident_, or for their participation in such resolution or reporting (including participation as _arbiter_), where _negative consequence_ is defined as any consequence that does or is intended to have the effect of harming the _member's_ career.
  * **Insulting**. We define _insulting_ as any _communication_ of the idea that any _personal attribute_ of any person is inferior, including all personal insults and ad hominem. Explicitly excluded from _insulting_ is all _communication_ of the idea that objective, falsifiable statements espoused by a _member_ are inconsistent, unsupported, or falsified, as well as _communication_ of the idea that some _personal attributes_ offer an advantage or disadvantage in obtaining specified measurable objectives.
- * **Stereotype**. We define a _stereotype_ to be a belief in the presence of a _personal attribute_ of an individual based not on direct evidence, but on their perceived membership in some unrelated or loosely related group or category.
  * **Violation**. We define _violation_ as an actual infringement of FCOP as determined by an _arbiter_.
  * **Violator**. We define _violator_ as an _accused member_ who has broken the terms and conditions of FCOP, as determined by an _arbiter_.
- * **Uncivil**. We define _uncivil_ individuals as individuals for whom one or more of the following currently hold:
-    * We believe the individual likely to engage in _criminal behavior_, and we or other individuals have contacted authorities to report the behavior that motivated this belief.
-    * We believe the individual likely to engage in _community sabotage_, and the individual has participated in previous _community sabotage_ or there is credible evidence suggesting the individual is planning to engage in future _community sabotage_.
-    * We believe the individual likely to engage in _professional sabotage_, and the individual has participated in previous _professional sabotage_ or there is credible evidence suggesting the individual is planning to engage in future _professional sabotage_.
- * **Unprofessional Behavior**. We define _unprofessional behavior_ as _discrimination_, _harassing_, _prying_, and _insulting_ during _active participation_, and _doxxing_ and _retaliating_ during _inactive participation_.
+ * **Uncivil**. We define _uncivil_ individuals as individuals for whom one or more of the following hold:
+    * We believe the individual is likely to engage in _criminal conduct_, and we or other individuals have contacted authorities to report the _conduct_ that motivated this belief.
+    * We believe the individual is likely to engage in _community sabotage_, and the individual has participated in previous _community sabotage_ or there is credible evidence suggesting the individual is planning to engage in future _community sabotage_.
+    * We believe the individual is likely to engage in _professional sabotage_, and the individual has participated in previous _professional sabotage_ or there is credible evidence suggesting the individual is planning to engage in future _professional sabotage_.
+ * **Unprofessional Conduct**. We define _unprofessional conduct_ as _harassing_, _prying_, and _insulting_ during _active participation_, and _doxxing_ and _retaliating_ during _inactive participation_.
+ * **Unqualified Individual**. We defined _unqualified individual_ to be an individual that is not a _qualified individual_.
  * **We**. We define _we_ to be those who have the actual or legal ability to impose FCOP-prescribed consequences on _violators_ within the physical or virtual boundaries of the _community_.
 
 ## License
@@ -125,4 +121,4 @@ These requirements on _behavior_ apply to _members_ at all times, even when they
 This work is licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/legalcode), with the following two exceptions:
 
  * We allow the creation of derivative works that are exclusively created and used for the submission of pull requests to the [official FCOP repository](http://github.com/fantasylandinst/fcop/). By submitting such a pull request, you unconditionally and irrevocably assign and transfer all ideas, concepts, copyrighted materials and trademarks within the submission to Fantasyland Institute of Learning.
- * We allow the creation of derivative works that strip out all references to "FCOP" and "Fantasyland Institute of Learning", and license all such derivative works under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/).
+ * We allow the creation of derivative works that strip out all references to "FCOP" and "Fantasyland Institute of Learning", and license all such derivative works under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/), and provide public attribution to FCOP.

--- a/EVOLUTION.md
+++ b/EVOLUTION.md
@@ -3,6 +3,6 @@
 1. Policies may not be influenced by social media, with a mandatory cool down period of at least 60 days between an event on social media, and a reactionary change to FCOP.
 2. Policies may only dictate behavior, not internal or external characteristics of members.
 3. Policies may not promote any agenda other than the professional goals of the community, and as a component of this, continued participation in professional life for members.
-4. Policies must guard against the formation of corrupt FCOP communities.
-5. Policies must not attempt to eliminate the use of subjective human arbitration, only to limit its scope to well-defined boundaries.
-6. Policies must not attempt to replace or extend the legal system in the country of jurisdiction, but must assume a functioning legal system that is responsible for handling all civil and criminal offenses.
+4. Policies must not attempt to eliminate the use of subjective human arbitration, only to limit its scope. As a consequence of this, policies must not dictate what _will_ happen, but only what is _allowed_ to happen.
+5. Policies must not attempt to replace or extend the legal system in the country of jurisdiction, but must assume a functioning legal system that is responsible for handling all civil and criminal offenses.
+6. To the extent possible, policies must protect against corrupt FCOP communities, and must protect the innocent, rather than being biased toward *Aggrieved* or *Accused*.

--- a/FAQ.md
+++ b/FAQ.md
@@ -65,3 +65,7 @@ FCOP does not overlap with or supersede local jurisdiction. If anyone breaks any
 ### 14. What are the ways in which FCOP can be customized?
 
 FCOP can be customized by imposing additional or overriding existing terms and conditions. FCOP can also be customized by specifying a set of guidelines for arbitration that help members understand the directives that arbiters will utilize when trying to resolve incidents.
+
+### 15. Does FCOP engage in tone policing?
+
+FCOP does not require any particular tone be used in communication. Rather, FCOP relies on the *No harassment* clause to deal with undesired communication tones. If someone is not being addressed in a tone they wish to be addressed in, they have the option to prevent others from interacting with them.


### PR DESCRIPTION
Among other changes, fixes #71, #101, #107.

 * Added the "no nazi" clause via community qualifications.
 * Dramatically simplified the copy and removed redundancy, without significantly changing meaning.
 * Added a version to the COC.
 * Various minor improvements to wording & terminology.